### PR TITLE
fix: 로그인 페이지 접근 수정

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -31,7 +31,12 @@ const onlyAuthUser = async (to, from, next) => {
   }
 
   if (!isValidToken.value || userInfo.value === null) {
-    next({ name: "login" });
+    if (to.path === "/") next();
+    else next({ name: "login" });
+  }
+  // 로그인 상태에서 / 경로로 접근 시, "main"으로
+  else if (isValidToken.value && userInfo.value !== null && to.path === "/") {
+    next({ name: "main" });
   } else {
     next();
   }
@@ -43,6 +48,7 @@ const router = createRouter({
     {
       path: "/",
       name: "login",
+      beforeEnter: onlyAuthUser,
       component: LoginView,
     },
     {


### PR DESCRIPTION
- 로그인 상태에서 로그인 페이지 ("/") 접근 시, main으로 우회

## 📌 Related Issue

- Closes #57 

<br/>

## ✏ Content

vue router가 담긴 index.js 내 beforeEnter 네비게이션 가드를 수정했습니다.
- 로그인 상태이면서, "/" 경로로 접근 시, "/main" 경로로 이동할 수 있도록 코드를 추가했습니다.
- 로그아웃 시 "/" 경로로 무한루프 되는 것을 막기 위해, 로그아웃 상태에 to.path를 확인하는 코드도 추가했습니다.

<br/>

## 📑 참고 사항
